### PR TITLE
Write 0 not 0A000h to di

### DIFF
--- a/main.asm
+++ b/main.asm
@@ -293,7 +293,7 @@ int 21h
 	mov es, ax
 	mov dl, 0x0
 	mov cx, 64000
-	mov di, ax
+	mov di, 0x0
 	.cls_loop:
 		mov [es:di], dl
 		inc di


### PR DESCRIPTION
Hi, I think this might be a bug. Writing AX to DI means putting 0A000h in DI, that value is the selector not the offset when writing to screen memory in mode 13.

Writing 0 appears to fix the artefacts that are left on the screen two-thirds of the way down.